### PR TITLE
תבנית קנונית להצעת שינוי דרישה

### DIFF
--- a/templates/REQUIREMENT_CHANGE_PROPOSAL.md
+++ b/templates/REQUIREMENT_CHANGE_PROPOSAL.md
@@ -1,0 +1,39 @@
+# הצעת שינוי דרישה
+
+> תבנית פלט ל־`capture-requirement`. מילוי התבנית אינו משנה זיכרון או קוד.
+
+## הדרישה המקורית
+`[המשפט המדויק של יניב, ללא מידע רגיש]`
+
+## סיווג
+- סוג: `[global-preference / project-rule / product-contract / architecture-decision / current-state / open-task / evidence / sensitive / not-memory]`
+- Scope: `[global / repository / path / feature]`
+- רגישות: `[public-safe / private / prohibited]`
+- ודאות: `[high / medium / low]`
+
+## נוסח קנוני מוצע
+> `[משפט אחד עד שלושה, קצר וניתן לבדיקה]`
+
+## מה נמצא כבר
+| מקור | סעיף/נתיב | יחס לדרישה | סטטוס |
+|---|---|---|---|
+| `[path]` | `[section]` | `[identical / overlap / update / conflict]` | `[active / stale / unknown]` |
+
+## הפעולה המוצעת
+- פעולה: `[no-op / update / replace / supersede / save-as-state / create-task / do-not-store]`
+- יעד: `[path או מערכת פרטית]`
+- מה יוחלף: `[אין / סעיף קיים]`
+- מה לא ישתנה: `[scope מוגן]`
+
+## אכיפה מומלצת
+- מנגנון: `[none / test / verifier / schema / Rule / Permission / Hook / Skill]`
+- סיבה: `[מדוע טקסט בלבד מספיק או אינו מספיק]`
+
+## בדיקות לאחר אישור
+- `[בדיקת כפילות]`
+- `[בדיקת סתירה]`
+- `[test/verifier רלוונטי]`
+- `[git diff מלא]`
+
+## אישור נדרש
+`[הפעולה המדויקת שתבוצע רק לאחר אישור יניב]`


### PR DESCRIPTION
## מטרה
להוסיף פורמט אחיד שבו `capture-requirement` יציג הצעת שינוי לפני כל כתיבה.

## מה נוסף
- `templates/REQUIREMENT_CHANGE_PROPOSAL.md`

## התבנית כוללת
- סיווג, scope ורגישות.
- ניסוח קנוני מוצע.
- כפילות או סתירה שנמצאה.
- יעד אחד לשמירה.
- מה יוחלף ומה מוגן.
- אכיפה מומלצת.
- בדיקות לאחר אישור.
- הפעולה המדויקת שממתינה לאישור יניב.

## גבולות
- אין התקנת Skill.
- אין שינוי קוד או הגדרות.
- אין כתיבה אוטומטית לזיכרון.
- אין מידע אישי או רגיש.

## אימות
- ענף נקי המבוסס על `main` העדכני.
- קובץ Markdown אחד בלבד.
